### PR TITLE
[Fix] fixed .pdbrc not working for python3 pdb problem

### DIFF
--- a/dotfiles-common/.pdbrc
+++ b/dotfiles-common/.pdbrc
@@ -10,4 +10,5 @@
 # hurt).
 
 import os
-execfile(os.path.expanduser("~/.pdbrc.py"))
+# execfile(os.path.expanduser("~/.pdbrc.py"))
+exec(compile(open(os.path.expanduser("~/.pdbrc.py"), "rb").read(), os.path.expanduser("~/.pdbrc.py"), 'exec'))


### PR DESCRIPTION
replace deprecated `execfile` with portable `exec`, make .pdbrc works
both for python2 and python3