### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/audit-defaults.yaml
+++ b/.github/workflows/audit-defaults.yaml
@@ -14,6 +14,6 @@ jobs:
     # the default 6-hour cap would burn a full runner-hour budget before dying.
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Audit macos-config.sh keys
         run: python3 ./tools/audit_defaults.py --scan ./macos-config.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,7 +56,7 @@ jobs:
     name: Run full installation
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Zsh
         run: |
           brew install zsh


### PR DESCRIPTION
## 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `1 week`: releases after `2026-07-31` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [actions/checkout](https://github.com/actions/checkout) | [`v6.0.2` → `v7.0.1`](https://github.com/actions/checkout/compare/v6.0.2...v7.0.1) | 2026-07-20 (a month ago) |

### Release notes

<details>
<summary><code>actions/checkout</code></summary>

#### [`v6.0.3`](https://github.com/actions/checkout/releases/tag/v6.0.3)

##### What's Changed
* Update changelog by @​ericsciple in https://redirect.github.com/actions/checkout/pull/2357
* fix: expand merge commit SHA regex and add SHA-256 test cases by @​yaananth in https://redirect.github.com/actions/checkout/pull/2414
* Fix checkout init for SHA-256 repositories by @​yaananth in https://redirect.github.com/actions/checkout/pull/2439
* Update changelog for v6.0.3 by @​yaananth in https://redirect.github.com/actions/checkout/pull/2446

##### New Contributors
* @​yaananth made their first contribution in https://redirect.github.com/actions/checkout/pull/2414

**Full Changelog**: https://redirect.github.com/actions/checkout/compare/v6...v6.0.3

#### [`v6.1.0`](https://github.com/actions/checkout/releases/tag/v6.1.0)

##### What's Changed
* **[BREAKING]** backport `allow-unsafe-pr-checkout` to v6 by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2500
* backport fixes to releases-v6 by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2527

https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/ for more details about this breaking change

**Full Changelog**: https://redirect.github.com/actions/checkout/compare/v6.0.3...v6.1.0

#### [`v7.0.0`](https://github.com/actions/checkout/releases/tag/v7.0.0)

##### What's Changed
* block checking out fork pr for pull_request_target and workflow_run by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2454
* Bump actions/publish-immutable-action from 0.0.3 to 0.0.4 in the minor-actions-dependencies group across 1 directory by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2458
* Bump flatted from 3.3.1 to 3.4.2 by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2460
* Bump js-yaml from 4.1.0 to 4.2.0 by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2461
* Bump @​actions/core and @​actions/tool-cache and Remove uuid by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2459
* upgrade module to esm and update dependencies by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2463
* Bump the minor-npm-dependencies group across 1 directory with 3 updates by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2462
* getting ready for checkout v7 release by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2464
* update error wording by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2467

##### New Contributors
* @​aiqiaoy made their first contribution in https://redirect.github.com/actions/checkout/pull/2454

**Full Changelog**: https://redirect.github.com/actions/checkout/compare/v6.0.3...v7.0.0

#### [`v7.0.1`](https://github.com/actions/checkout/releases/tag/v7.0.1)

##### What's Changed
* skip running unsafe pr check if input is default by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2518
* trim only ascii whitespace for branch by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2521
* escape values passed to --unset by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2530
* Various dependency updates 

**Full Changelog**: https://redirect.github.com/actions/checkout/compare/v7...v7.0.1

</details>

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/dotfiles/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-action-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-action-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`aca64966`](https://github.com/kdeldycke/dotfiles/commit/aca6496680d2fc6ccce58a4425679fdefc702050)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/dotfiles/blob/aca6496680d2fc6ccce58a4425679fdefc702050/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/dotfiles/blob/aca6496680d2fc6ccce58a4425679fdefc702050/.github/workflows/autofix.yaml)
- **Run**: [#500.1](https://github.com/kdeldycke/dotfiles/actions/runs/31214004186)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.5.0`